### PR TITLE
Updated RegExp for Data URI's

### DIFF
--- a/selectivizr.js
+++ b/selectivizr.js
@@ -70,7 +70,7 @@ References:
 	// Stylesheet parsing regexp's
 	var RE_COMMENT							= /(\/\*[^*]*\*+([^\/][^*]*\*+)*\/)\s*/g
 	var RE_IMPORT							= /@import\s*(?:(?:(?:url\(\s*(['"]?)(.*)\1)\s*\))|(?:(['"])(.*)\3))[^;]*;/g
-	var RE_ASSET_URL 						= /\burl\(\s*(["']?)([^"')]+)\1\s*\)/g;
+	var RE_ASSET_URL 						= /\burl\(\s*(["']?)(?!data)([^"')]+)\1\s*\)/g;
 	var RE_PSEUDO_STRUCTURAL				= /^:(empty|(first|last|only|nth(-last)?)-(child|of-type))$/
 	var RE_PSEUDO_ELEMENTS					= /:(:first-(?:line|letter))/g
 	var RE_SELECTOR_GROUP					= /(^|})\s*([^\{]*?[\[:][^{]+)/g

--- a/selectivizr.js
+++ b/selectivizr.js
@@ -70,7 +70,7 @@ References:
 	// Stylesheet parsing regexp's
 	var RE_COMMENT							= /(\/\*[^*]*\*+([^\/][^*]*\*+)*\/)\s*/g
 	var RE_IMPORT							= /@import\s*(?:(?:(?:url\(\s*(['"]?)(.*)\1)\s*\))|(?:(['"])(.*)\3))[^;]*;/g
-	var RE_ASSET_URL 						= /\burl\(\s*(["']?)(?!data)([^"')]+)\1\s*\)/g;
+	var RE_ASSET_URL 						= /\burl\(\s*(["']?)(?!data:)([^"')]+)\1\s*\)/g;
 	var RE_PSEUDO_STRUCTURAL				= /^:(empty|(first|last|only|nth(-last)?)-(child|of-type))$/
 	var RE_PSEUDO_ELEMENTS					= /:(:first-(?:line|letter))/g
 	var RE_SELECTOR_GROUP					= /(^|})\s*([^\{]*?[\[:][^{]+)/g


### PR DESCRIPTION
I was encountering some issues earlier today where Data URI's were being converted into file URL's by Selectivizr, generating junk HTTP requests and preventing the images from being rendered. I've updated the RegExp to exclude them.
