### PR TITLE
MooTools and JQuery updated to latest versions

### DIFF
--- a/tests/master/index.html
+++ b/tests/master/index.html
@@ -17,14 +17,19 @@
 				"2.7": "http://domassistant.googlecode.com/files/DOMAssistant-2.7.4.js"
 			},
 			"MooTools": {
-				"1.3.1": "http://mootools.net/download/get/mootools-core-1.3.1-full-nocompat-yc.js",
+				"EDGE": "http://mootools.net/nightly/build/mootools-core.js",
+				"1 (latest)": "https://ajax.googleapis.com/ajax/libs/mootools/1/mootools-yui-compressed.js",
+				"1.3.2": "http://ajax.googleapis.com/ajax/libs/mootools/1.3.2/mootools-yui-compressed.js",
+				"1.3.1": "http://ajax.googleapis.com/ajax/libs/mootools/1.3.1/mootools-yui-compressed.js",
 				"1.3": "http://mootools.net/download/get/mootools-core-1.3-full-nocompat-yc.js",
 				"1.2.5": "http://mootools.net/download/get/mootools-1.2.5-core-yc.js"
 			},
 			"JQuery": {
-				"1.5": "http://code.jquery.com/jquery-1.5.min.js",
-				"1.4": "http://code.jquery.com/jquery-1.4.min.js",
-				"1.3": "http://code.jquery.com/jquery-1.3.min.js"
+				"1 (latest)": "http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js",
+				"1.6": "http://ajax.googleapis.com/ajax/libs/jquery/1.6/jquery.min.js",
+				"1.5": "http://ajax.googleapis.com/ajax/libs/jquery/1.5/jquery.min.js",
+				"1.4": "http://ajax.googleapis.com/ajax/libs/jquery/1.4/jquery.min.js",
+				"1.3": "http://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"
 			},
 			"Dojo": {
 				"1.5": "http://ajax.googleapis.com/ajax/libs/dojo/1.5/dojo/dojo.xd.js"


### PR DESCRIPTION
- MooTools v1 latest added 
- MooTools EDGE added 
- JQuery 1.6 added 
- JQuery v1 latest added 
- Updated MooTools and JQuery test engines to use google api's. As new subversions (1.6.x) become available they are automatically used.
