### PR TITLE
Make getProtocolAndHost work on URLs that doesn't end with `/`

### DIFF
--- a/selectivizr.js
+++ b/selectivizr.js
@@ -404,7 +404,8 @@ References:
 		};
 
 		function getProtocolAndHost( url ) {
-			return url.substring(0, url.indexOf("/", 8));
+			var index = url.indexOf("/", 8);
+			return index > -1 ? url.substring(0, index) : url;
 		};
 
 		if (!contextUrl) {


### PR DESCRIPTION
`getProtocolAndHost` doesn't work properly when the `<base href>` is set without a trailing `/` (e.g. https://github.com). I know its technically not correct for URLs to have no path at all, but this caused me some issues because of the way WordPress stores the base URL (see the last paragraph [here](http://www.shesek.info/web-development/selectivizr-internet-explorer-and-idn-domains) [the rest of the post might be interesting too, perhaps it could be solved in Selectivizr?]).
