### PR TITLE
Avoid error when stylesheet doesn't have an href

### DIFF
--- a/selectivizr.js
+++ b/selectivizr.js
@@ -462,7 +462,7 @@ References:
 		var url, stylesheet;
 		for (var c = 0; c < doc.styleSheets.length; c++) {
 			stylesheet = doc.styleSheets[c];
-			if (stylesheet.href != EMPTY_STRING) {
+			if (stylesheet.href && (stylesheet.href != EMPTY_STRING)) {
 				url = resolveUrl(stylesheet.href);
 				if (url) {
 					stylesheet.cssText = stylesheet["rawCssText"] = patchStyleSheet( parseStyleSheet( url ) );


### PR DESCRIPTION
I am getting an error when the href on a stylesheet is null. The current code is checking for an empty string but not null. This patch fixes this.

For an example use case I am getting null on the href via the stylesheet tag generated by the htm5shiv.js which adds support for HTML5 elements to older versions of IE.
