### PR TITLE
@import rules with minified CSS that contains other 'url' rules will fail to parse @import's url

### DIFF
--- a/selectivizr.js
+++ b/selectivizr.js
@@ -72,7 +72,7 @@ References:
 
 	// Stylesheet parsing regexp's
 	var RE_COMMENT							= /(\/\*[^*]*\*+([^\/][^*]*\*+)*\/)\s*?/g;
-	var RE_IMPORT							= /@import\s*(?:(?:(?:url\(\s*(['"]?)(.*)\1)\s*\))|(?:(['"])(.*)\3))\s*([^;]*);/g;
+	var RE_IMPORT							= /@import\s*(?:(?:(?:url\(\s*(['"]?)([^;]*)\1)\s*\))|(?:(['"])([^;]*)\3))\s*([^;]*);/g;
 	var RE_ASSET_URL 						= /(behavior\s*?:\s*)?\burl\(\s*(["']?)(?!data:)([^"')]+)\2\s*\)/g;
 	var RE_PSEUDO_STRUCTURAL				= /^:(empty|(first|last|only|nth(-last)?)-(child|of-type))$/;
 	var RE_PSEUDO_ELEMENTS					= /:(:first-(?:line|letter))/g;

--- a/tests/master/css/import-print.css
+++ b/tests/master/css/import-print.css
@@ -1,6 +1,6 @@
 /* if @media type filtering doesn't work we want this test to fail */
 
 tr#import-print { 
-	background: #c00; 
+	background: #0c0; 
 }
 

--- a/tests/master/css/master.css
+++ b/tests/master/css/master.css
@@ -29,7 +29,25 @@
 @import url("import-print.css") print;
 @import url("import-screen.css") screen;
 
+/* When parsing @import of minified CSS, ensure the Regex isn't too greedy */
+@import url("min-import-url-quoted-double.css");.minified{background:url("css/nested/test.png");}
+@import url('min-import-url-quoted-single.css');.minified{background:url("css/nested/test.png");}
+@import url(min-import-url-unquoted.css);.minified{background:url("css/nested/test.png");}
+@import "min-import-quoted-double.css";.minified{background:url("css/nested/test.png");}
+@import "min-import-quoted-single.css";.minified{background:url("css/nested/test.png");}
+@import url("nested/min-import-url-relative-path.css");.minified{background:url("css/nested/test.png");}
+/* 
+ * The following urls will be specific to your own server configuration and will fail  
+ * if used "out of the box". To test root-relative and fully qualifed url's you will 
+ * need to adjust the paths below:
+ */
 
+@import url("/selectivizr-git/tests/master/css/min-import-url-root-relative-path.css");.minified{background:url("css/nested/test.png");}
+@import url("http://iis/selectivizr-git/tests/master/css/min-import-url-fully-qualified-path.css");.minified{background:url("css/nested/test.png");}
+@import url("//iis/selectivizr-git/tests/master/css/min-import-url-protocol-relative-path.css");.minified{background:url("css/nested/test.png");}
+
+@import url("min-import-print.css") print;.minified{background:url("css/nested/test.png");}
+@import url("min-import-screen.css") screen;.minified{background:url("css/nested/test.png");}
 
 body {
 	padding: 10px;

--- a/tests/master/css/master.css
+++ b/tests/master/css/master.css
@@ -29,13 +29,7 @@
 @import url("import-print.css") print;
 @import url("import-screen.css") screen;
 
-#import-print {
-	background: #0c0;
-}
 
-#import-screen {
-	background: #c00;
-}
 
 body {
 	padding: 10px;

--- a/tests/master/css/min-import-print.css
+++ b/tests/master/css/min-import-print.css
@@ -1,0 +1,6 @@
+/* if @media type filtering doesn't work we want this test to fail */
+
+tr#min-import-print { 
+	background: #0c0; 
+}
+

--- a/tests/master/css/min-import-quoted-double.css
+++ b/tests/master/css/min-import-quoted-double.css
@@ -1,0 +1,1 @@
+#min-import-quoted-double { background-color: #0c0 }

--- a/tests/master/css/min-import-quoted-single.css
+++ b/tests/master/css/min-import-quoted-single.css
@@ -1,0 +1,1 @@
+#min-import-quoted-single { background-color: #0c0 }

--- a/tests/master/css/min-import-screen.css
+++ b/tests/master/css/min-import-screen.css
@@ -1,0 +1,4 @@
+tr#min-import-screen { 
+	background: #0c0; 
+}
+

--- a/tests/master/css/min-import-url-fully-qualified-path.css
+++ b/tests/master/css/min-import-url-fully-qualified-path.css
@@ -1,0 +1,1 @@
+#min-import-url-fully-qualfied { background-color: #0c0 }

--- a/tests/master/css/min-import-url-protocol-relative-path.css
+++ b/tests/master/css/min-import-url-protocol-relative-path.css
@@ -1,0 +1,3 @@
+#min-import-url-protocol-relative {
+	background: #0c0;
+}

--- a/tests/master/css/min-import-url-quoted-double.css
+++ b/tests/master/css/min-import-url-quoted-double.css
@@ -1,0 +1,1 @@
+#min-import-url-quoted-double { background-color: #0c0 }

--- a/tests/master/css/min-import-url-quoted-single.css
+++ b/tests/master/css/min-import-url-quoted-single.css
@@ -1,0 +1,1 @@
+#min-import-url-quoted-single { background-color: #0c0 }

--- a/tests/master/css/min-import-url-root-relative-path.css
+++ b/tests/master/css/min-import-url-root-relative-path.css
@@ -1,0 +1,1 @@
+#min-import-url-root-relative { background-color: #0c0 }

--- a/tests/master/css/min-import-url-unquoted.css
+++ b/tests/master/css/min-import-url-unquoted.css
@@ -1,0 +1,1 @@
+#min-import-url-unquoted { background-color: #0c0 }

--- a/tests/master/css/nested/min-import-url-relative-path.css
+++ b/tests/master/css/nested/min-import-url-relative-path.css
@@ -1,0 +1,1 @@
+#min-import-url-relative { background-image: url("test.png") }

--- a/tests/master/index.html
+++ b/tests/master/index.html
@@ -111,6 +111,54 @@
 			</tr>
 		</table>
 
+		<h3>Minified @import syntax tests</h3>
+		<table border="1" width="100%">
+			<tr id="min-import-url-quoted-double">
+				<td>@import url("...")</td>
+				<td>Testing @import rule with url wrapped in double quotes and prefixed with the url() qualifier
+			</tr>
+			<tr id="min-import-url-quoted-single">
+				<td>@import url('...')</td>
+				<td>Testing @import rule with url wrapped in single quotes and prefixed with the url() qualifier
+			</tr>
+			<tr id="min-import-url-unquoted">
+				<td>@import url(...)</td>
+				<td>Testing @import rule with url without quotes and prefixed with the url() qualifier
+			</tr>
+			<tr id="min-import-quoted-double">
+				<td>@import "..."</td>
+				<td>Testing @import rule with url wrapped in double quotes without the url() qualifier
+			</tr>
+			<tr id="min-import-quoted-single">
+				<td>@import '...'</td>
+				<td>Testing @import rule with url wrapped in single quotes without the url() qualifier
+			</tr>
+			<tr id="min-import-url-relative">
+				<td>@import url("../file.css")</td>
+				<td>Testing @import rule with a relative path
+			</tr>
+			<tr id="min-import-url-root-relative">
+				<td>@import url("/path/file.css")</td>
+				<td>Testing @import rule with a root-relative path (see note in 'master.css')
+			</tr>
+			<tr id="min-import-url-fully-qualfied">
+				<td>@import url("http://domain/path/file.css")</td>
+				<td>Testing @import rule with a fully qualified path (see note in 'master.css')
+			</tr>
+			<tr id="min-import-url-protocol-relative">
+				<td>@import url("//domain/path/file.css")</td>
+				<td>Testing @import rule with a protocol relative path
+			</tr>
+			<tr id="min-import-print">
+				<td>@import url("...") print</td>
+				<td>Testing @import rule with a print media type
+			</tr>
+			<tr id="min-import-screen">
+				<td>@import url("...") screen</td>
+				<td>Testing @import rule with a screen media type
+			</tr>
+		</table>
+
 		<h3>url syntax tests</h3>
 		<table border="1" width="100%">
 			<tr id="url-quoted-double">


### PR DESCRIPTION
Examples include:

``` css
@import url("min-import-url-quoted-double.css");.minified{background:url("css/nested/test.png");}

/* Which will incorrectly match the URL of the css file as: */
min-import-url-quoted-double.css");.minified{background:url("css/nested/test.png
```

``` css
@import "min-import-quoted-double.css";.minified{background:url("css/nested/test.png");}

/* Which will incorrectly match the URL of the css file as: */
min-import-quoted-double.css";.minified{background:url("css/nested/test.png
```

This fix updates the @import regex to fix this issue.

_Note_: See the tests/master/index.html for the unit tests, which have _only been tested in IE8_!
