### PR TITLE
Added bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,5 @@
+{
+  "name": "selectivizr",
+  "version": "1.0.3",
+  "main": "selectivizr.js"
+}


### PR DESCRIPTION
selectivizr is already IN the bower repository — accepting this pull request will make users of bower & selectivizr happy. 

Bower uses tags, so as per #67, it'd be great if you could

`git tag 1.0.3` 

After accepting this pull request (or use the new github releases feature).

Lemme know if you have any questions, I'll do my best to answer.

This will close Ref: #62 when merged. 
