### PR TITLE
Whitespace normalization and regex simplification

### DIFF
--- a/selectivizr.js
+++ b/selectivizr.js
@@ -394,7 +394,7 @@ References:
 	function loadStyleSheet( url ) {
 		xhr.open("GET", url, false);
 		xhr.send();
-		return (xhr.status==200) ? xhr.responseText : EMPTY_STRING;	
+		return (xhr.status==200) ? normalizeWhitespace(xhr.responseText) : EMPTY_STRING;
 	};
 	
 	// --[ resolveUrl() ]---------------------------------------------------

--- a/selectivizr.js
+++ b/selectivizr.js
@@ -71,7 +71,7 @@ References:
 	var namespace 							= "slvzr";
 
 	// Stylesheet parsing regexp's
-	var RE_COMMENT							= /(\/\*[^*]*\*+([^\/][^*]*\*+)*\/)\s*?/g;
+	var RE_COMMENT							= /\/\*[\S\s]*?\*\//g;
 	var RE_IMPORT							= /@import\s*(?:(?:(?:url\(\s*(['"]?)(.*)\1)\s*\))|(?:(['"])(.*)\3))\s*([^;]*);/g;
 	var RE_ASSET_URL 						= /(behavior\s*?:\s*)?\burl\(\s*(["']?)(?!data:)([^"')]+)\2\s*\)/g;
 	var RE_PSEUDO_STRUCTURAL				= /^:(empty|(first|last|only|nth(-last)?)-(child|of-type))$/;


### PR DESCRIPTION
The RE_COMMENT regex seems unnecessarily complex: I've simplified it.

The whitespace normalization is the focus of this pull request. I'm working with Rails' asset pipeline and I found a peculiarity where one of its resulting CSS assets contains over 5,000 spaces (between two sheets that it pulled together). This is causing selectivizr to hang; I suspect the excessive space may be triggering "catastrophic backtracking." I've wrapped the loaded stylesheet with normalizeWhitespace to prevent this from happening.
