### PR TITLE
IE9+ Agent with documentMode < 9 Bug

### DIFF
--- a/selectivizr.js
+++ b/selectivizr.js
@@ -44,7 +44,7 @@ References:
 	// If were not in standards mode, IE is too old / new or we can't create
 	// an XMLHttpRequest object then we should get out now.
 	if (doc.compatMode != 'CSS1Compat' || ieVersion<6 || ieVersion>8 || !xhr) {
-	        if(document.documentMode > 8 || document.documentMode === "undefined") {
+	        if(document.documentMode > 8 || typeof document.documentMode === "undefined") {
 	            return;
 	        }
 	}

--- a/selectivizr.js
+++ b/selectivizr.js
@@ -44,7 +44,9 @@ References:
 	// If were not in standards mode, IE is too old / new or we can't create
 	// an XMLHttpRequest object then we should get out now.
 	if (doc.compatMode != 'CSS1Compat' || ieVersion<6 || ieVersion>8 || !xhr) {
-		return;
+	        if(document.documentMode > 8 || document.documentMode === "undefined") {
+	            return;
+	        }
 	}
 	
 	


### PR DESCRIPTION
In some instances IE can use a Bowser Mode of IE9+ while at the same time run a Document Mode like IE7 which selectivizr is designed to enhance.

In such cases selectivizr does not run. This fix should address the issue and cause IE to use selectivizr based on Document Mode as well not just the ieVersion.
